### PR TITLE
fix: Show tool name in suggested issue title

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -36,4 +36,4 @@ Contributions of new HEP tools are very welcome!
 
 To get a new tool listed:
 1. Package and distribute your tool on conda-forge.
-2. Open up an Issue with title "Add <tool name> to HEP Packaging Coordination" with a link to the tool's conda-forge feedstock.
+2. Open up an [Issue](https://github.com/hep-packaging-coordination/.github/issues) with title "Add `<tool name>` to HEP Packaging Coordination" with a link to the tool's conda-forge feedstock.


### PR DESCRIPTION
* Escape <tool-name> with backticks to have it get rendered correctly in the README.
* Add link to new Issue.