### PR TITLE
chore: Remove timestamp update

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-cache: auto
-          cache-dependency-glob: '**/uv.lock'
+          cache-dependency-glob: "**/uv.lock"
           prune-cache: true
 
       - name: Install Python dependencies

--- a/update_readme.py
+++ b/update_readme.py
@@ -3,7 +3,6 @@ import json
 import os
 import requests
 from collections import defaultdict
-from datetime import datetime, timezone
 
 
 def load_feedstock_outputs():
@@ -136,10 +135,6 @@ def main():
         '2. Open up an [Issue](https://github.com/hep-packaging-coordination/.github/issues) with title "Add `<tool name>` to HEP Packaging Coordination" with a link to the tool\'s conda-forge feedstock.'
     )
     lines.append("")
-
-    # Append the last updated timestamp in UTC.
-    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-    lines.append(f"Last updated: {now_utc}")
 
     # Write output to README.md in the "profile" directory relative to this script.
     script_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
* Adding the timestamp breaks checking for no changes and leads to noisy commits.
   - c.f. https://github.com/hep-packaging-coordination/.github/issues/4#issuecomment-2631596997 for context.
* Apply pre-commit fixes.